### PR TITLE
xml2var: fix indentation to silence compiler warning

### DIFF
--- a/src/nkit/xml2var.h
+++ b/src/nkit/xml2var.h
@@ -1408,7 +1408,7 @@ namespace nkit
       if (!child_target_item)
         return TargetItemPtr();
 
-        target->PutTargetItem(child_target_item);
+      target->PutTargetItem(child_target_item);
 
       TargetItemPtr target_item = TargetItem<T>::Create(fool_path,
           target);


### PR DESCRIPTION
Here's the compiler warning that triggered this change:
```| In file included from ../deps/nkit/src/xml/xml2var.cpp:1:
| ../deps/nkit/src/nkit/xml2var.h: In static member function 'static nkit::StructXml2VarBuilder<T>::TargetItemPtr nkit::StructXml2VarBuilder<T>::ParseListTargetSpec(nkit::Target<T>*, nkit::Path, const nkit::Dynamic&, const Ptr&, nkit::StructXml2VarBuilder<T>::PathNodePtr, nkit::StructXml2VarBuilder<T>::TargetItemVector*, nkit::String2IdMap*, std::__cxx11::string*)':
| ../deps/nkit/src/nkit/xml2var.h:1408:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
|        if (!child_target_item)
|        ^~
| ../deps/nkit/src/nkit/xml2var.h:1411:9: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'if'
|          target->PutTargetItem(child_target_item);
|          ^~~~~~
```